### PR TITLE
change the names of imported modules

### DIFF
--- a/cmd/lb/balancer.go
+++ b/cmd/lb/balancer.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/roman-mazur/design-practice-2-template/httptools"
-	"github.com/roman-mazur/design-practice-2-template/signal"
+	"github.com/roman-mazur/architecture-practice-4-template/httptools"
+	"github.com/roman-mazur/architecture-practice-4-template/signal"
 )
 
 var (

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/roman-mazur/design-practice-2-template/httptools"
-	"github.com/roman-mazur/design-practice-2-template/signal"
+	"github.com/roman-mazur/architecture-practice-4-template/httptools"
+	"github.com/roman-mazur/architecture-practice-4-template/signal"
 )
 
 var port = flag.Int("port", 8080, "server port")


### PR DESCRIPTION
Run `grep -rl 'github.com/roman-mazur/design-practice-2-template' | xargs sed -i 's/github.com\/roman-mazur\/design-practice-2-template/github.com\/roman-mazur\/architecture-practice-4-template/g'`

Because `docker build -t practice-4 .` throws this error:

```
 => ERROR [build 4/5] RUN go test ./...                                                                                                                                                    0.5s
------                                                                                                                                                                                          
 > [build 4/5] RUN go test ./...:                                                                                                                                                               
0.400 cmd/lb/balancer.go:12:2: no required module provides package github.com/roman-mazur/design-practice-2-template/httptools; to add it:                                                      
0.400 	go get github.com/roman-mazur/design-practice-2-template/httptools                                                                                                                      
0.400 cmd/lb/balancer.go:13:2: no required module provides package github.com/roman-mazur/design-practice-2-template/signal; to add it:
0.400 	go get github.com/roman-mazur/design-practice-2-template/signal
------
Dockerfile:6
--------------------
   4 |     COPY . .
   5 |     
   6 | >>> RUN go test ./...
   7 |     ENV CGO_ENABLED=0
   8 |     RUN go install ./cmd/...
--------------------
ERROR: failed to solve: process "/bin/sh -c go test ./..." did not complete successfully: exit code: 1

View build details: docker-desktop://dashboard/build/default/default/kzoct5xr1i0t6wokbjaq7ccib
```
