### PR TITLE
fixed launch of integration tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,4 +4,4 @@ WORKDIR /go/src/practice-4
 COPY . .
 
 ENV INTEGRATION_TEST=1
-RUN go test ./integration
+ENTRYPOINT ["go", "test", "./integration"]


### PR DESCRIPTION
Just replaced `RUN go test ./integration` with `ENTRYPOINT ["go", "test", "./integration"]` in Dockerfile.test.
Because `docker compose -f docker-compose.yaml -f docker-compose.test.yaml up --exit-code-from test` throw this errror:
```
 => ERROR [test 4/4] RUN go test ./integration                                                                                                                                            10.9s
------
 > [test 4/4] RUN go test ./integration:
10.42 --- FAIL: TestBalancer (0.02s)
10.42     balancer_test.go:25: Get "http://balancer:8090/api/v1/some-data": dial tcp: lookup balancer on 192.168.0.1:53: no such host
10.42 panic: runtime error: invalid memory address or nil pointer dereference [recovered]
10.42 	panic: runtime error: invalid memory address or nil pointer dereference
10.42 [signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x680fd5]
10.42 
10.42 goroutine 6 [running]:
10.42 testing.tRunner.func1.2({0x6b2fa0, 0x941be0})
10.42 	/usr/local/go/src/testing/testing.go:1631 +0x24a
10.42 testing.tRunner.func1()
10.42 	/usr/local/go/src/testing/testing.go:1634 +0x377
10.42 panic({0x6b2fa0?, 0x941be0?})
10.42 	/usr/local/go/src/runtime/panic.go:770 +0x132
10.42 github.com/roman-mazur/architecture-practice-4-template/integration.TestBalancer(0xc0000ae4e0)
10.42 	/go/src/practice-4/integration/balancer_test.go:27 +0xf5
10.42 testing.tRunner(0xc0000ae4e0, 0x731a10)
10.42 	/usr/local/go/src/testing/testing.go:1689 +0xfb
10.42 created by testing.(*T).Run in goroutine 1
10.42 	/usr/local/go/src/testing/testing.go:1742 +0x390
10.42 FAIL	github.com/roman-mazur/architecture-practice-4-template/integration	0.029s
10.42 FAIL
------
failed to solve: process "/bin/sh -c go test ./integration" did not complete successfully: exit code: 1

```

